### PR TITLE
Update Citrix Base URL

### DIFF
--- a/lib/citrix/training.rb
+++ b/lib/citrix/training.rb
@@ -17,6 +17,6 @@ require "citrix/training/serializer/training_date"
 
 module Citrix
   module Training
-    API_ENDPOINT = "https://api.citrixonline.com/G2T/rest".freeze
+    API_ENDPOINT = "https://api.goto.com/G2T/rest".freeze
   end
 end

--- a/lib/citrix/training.rb
+++ b/lib/citrix/training.rb
@@ -17,6 +17,6 @@ require "citrix/training/serializer/training_date"
 
 module Citrix
   module Training
-    API_ENDPOINT = "https://api.goto.com/G2T/rest".freeze
+    API_ENDPOINT = "https://api.getgo.com/G2T/rest".freeze
   end
 end


### PR DESCRIPTION
On December 4th, 2017 GoToDeveloper updated their base URL.
Here is the notice on their website:
![screenshot 2017-12-18 13 01 48](https://user-images.githubusercontent.com/12350239/34125936-2b100d0e-e3f5-11e7-8d11-1be1e48c21f7.png)


This PR updates that base_url so that this wrapper can again work with GoToTraining